### PR TITLE
Bug | Symbolic Analyzer | Errors on unrelated receivers

### DIFF
--- a/src/annotation/annotation.provider.ts
+++ b/src/annotation/annotation.provider.ts
@@ -262,7 +262,14 @@ export class AnnotationProvider {
 	}
 
 	private validateReceiver(): Diagnostic[] {
-		const validator = new ReceiverValidator(this._symbol as GolangReceiver, this);
+		const receiver = this._symbol as GolangReceiver;
+		if (!receiver.isApiEndpoint) {
+			// Receiver is not an API endpoint - we can ignore it.
+			// Note that this affects only contextual/semantic validation
+			return [];
+		}
+
+		const validator = new ReceiverValidator(receiver, this);
 		return validator.validate();
 	}
 

--- a/src/symbolic-analysis/golang.common.ts
+++ b/src/symbolic-analysis/golang.common.ts
@@ -1,4 +1,5 @@
 import { Range, DocumentSymbol } from 'vscode';
+import { GolangSymbolicAnalyzer } from './symbolic.analyzer';
 
 export enum GolangSymbolType {
 	Struct,
@@ -12,7 +13,10 @@ export abstract class GolangSymbol {
 		return this.symbol.range;
 	}
 
-	public constructor(public readonly symbol: DocumentSymbol) { }
+	public constructor(
+		public readonly analyzer: GolangSymbolicAnalyzer,
+		public readonly symbol: DocumentSymbol
+	) { }
 }
 
 export interface TypeParam {

--- a/src/symbolic-analysis/golang.receiver.ts
+++ b/src/symbolic-analysis/golang.receiver.ts
@@ -1,6 +1,7 @@
 import { inspect } from 'util';
 import { TextDocument, DocumentSymbol, Range } from 'vscode';
 import { TypeParam, GolangSymbol, GolangSymbolType } from './golang.common';
+import { GolangSymbolicAnalyzer } from './symbolic.analyzer';
 
 export interface ReceiverParameter extends TypeParam {
 	name: string;
@@ -22,8 +23,18 @@ export class GolangReceiver extends GolangSymbol {
 		return GolangSymbolType.Receiver;
 	}
 
-	public constructor(document: TextDocument, symbol: DocumentSymbol) {
-		super(symbol);
+	public get isApiEndpoint(): boolean {
+		// O(1) lookup
+		const owner = this.analyzer.getStructByName(this.ownerStructName);
+		return owner?.isController === true;
+	}
+
+	public constructor(
+		analyzer: GolangSymbolicAnalyzer,
+		document: TextDocument,
+		symbol: DocumentSymbol
+	) {
+		super(analyzer, symbol);
 
 		const match = symbol.name.match(/^\((?<isByRef>\*)?(?<typeName>\w+)\)\.(?<methodName>.+)/);
 		const name = match?.groups?.['methodName'];

--- a/src/symbolic-analysis/symbolic.analyzer.ts
+++ b/src/symbolic-analysis/symbolic.analyzer.ts
@@ -83,7 +83,7 @@ export class GolangSymbolicAnalyzer {
 		for (const symbol of symbols) {
 			switch (symbol.kind) {
 				case SymbolKind.Struct:
-					maybeController = new GolangStruct(symbol);
+					maybeController = new GolangStruct(this, symbol);
 					if (maybeController.isController) {
 						entity = maybeController;
 						this._structs.set(symbol.name, entity);
@@ -92,7 +92,7 @@ export class GolangSymbolicAnalyzer {
 				case SymbolKind.Method:
 					// Check if this is a receiver
 					if (/^\(\*?(?:\w+)\)\./.test(symbol.name)) {
-						const receiver = new GolangReceiver(this._document, symbol);
+						const receiver = new GolangReceiver(this, this._document, symbol);
 						entity = receiver;
 						if (!this._receivers.has(receiver.ownerStructName)) {
 							this._receivers.set(receiver.ownerStructName, [receiver]);


### PR DESCRIPTION
Addresses an issue where receivers with '//' comments are incorrectly validated via symbolic analysis by adding a check to determine if the receiver is a child of a  *Gleece* controller