### PR TITLE
Fixed issues relating to Gleece Config loading

### DIFF
--- a/src/common.constants.ts
+++ b/src/common.constants.ts
@@ -1,4 +1,6 @@
+// Should probably add i18n before this grows
 export const GoLangId = 'go';
 export const Gleece = 'gleece';
+export const GleeceCapitalized = 'Gleece';
 export const GleeceRuntimePackage = 'github.com/gopher-fleece/runtime';
 export const GoModFileName = 'go.mod';

--- a/src/common.constants.ts
+++ b/src/common.constants.ts
@@ -1,2 +1,4 @@
 export const GoLangId = 'go';
 export const Gleece = 'gleece';
+export const GleeceRuntimePackage = 'github.com/gopher-fleece/runtime';
+export const GoModFileName = 'go.mod';

--- a/src/configuration/config.manager.ts
+++ b/src/configuration/config.manager.ts
@@ -9,7 +9,7 @@ import {
 } from 'vscode';
 import { ExtensionRootNamespace, GleeceExtensionConfig } from './extension.config';
 import { GleeceConfig } from './gleece.config';
-import { readFile } from 'fs-extra';
+import { readFile } from 'fs/promises';
 import { Paths, PathValue } from '../typescript/paths';
 import { logger } from '../logging/logger';
 import { ITypedEvent, TypedEvent } from 'weak-event';

--- a/src/context/context.ts
+++ b/src/context/context.ts
@@ -128,7 +128,6 @@ class GleeceContext implements Disposable {
 		// The reasoning is that delegating disposal to the logger itself creates a cyclic dependency.
 		this._resourceManager.registerDisposable(logger);
 
-		this._configManager.registerConfigListener('analysis.enableSymbolicAwareness', this.onChangeSymbolicAwareness.bind(this));
 		const useSemanticAnalysis = this._configManager.getExtensionConfigValue('analysis.enableSymbolicAwareness') ?? false;
 		this.onChangeSymbolicAwareness({ previousValue: undefined, newValue: useSemanticAnalysis });
 
@@ -175,6 +174,13 @@ class GleeceContext implements Disposable {
 			}),
 			workspace.onDidCloseTextDocument((document) => this.diagnosticsProvider.onDocumentClosed(document))
 		);
+
+		this._configManager.registerConfigListener('analysis.enableSymbolicAwareness', this.onChangeSymbolicAwareness.bind(this));
+		this._configManager.isGleeceProjectChanged.attach((isGleeceProject) => {
+			if (isGleeceProject) {
+				this.invokeReAnalyze();
+			}
+		});
 
 		this._configManager.gleeceConfigChanged.attach(this.invokeReAnalyze.bind(this));
 	}

--- a/src/diagnostics/provider.ts
+++ b/src/diagnostics/provider.ts
@@ -47,11 +47,20 @@ export class GleeceDiagnosticsProvider implements Disposable {
 	}
 
 	public async onDemandFullDiagnostics(document: TextDocument): Promise<void> {
+		const logPrefix: string = '[GleeceDiagnosticsProvider.onDemandFullDiagnostic]';
+
 		if (document.languageId !== GoLangId) {
 			return;
 		}
 
+		// Keep track of the current file
 		this._currentDocument = document;
+
+		if (!gleeceContext.configManager.isGleeceProject) {
+			// Not a gleece project, don't analyze
+			return;
+		}
+
 		const start = Date.now(); // Need to define a better way than simple logs (preferably not application insights though)
 		let diagnostics: Diagnostic[];
 		const symbolicAnalysisEnabled = gleeceContext.configManager.getExtensionConfigValue('analysis.enableSymbolicAwareness');
@@ -65,8 +74,9 @@ export class GleeceDiagnosticsProvider implements Disposable {
 
 		this._diagnosticCollection.clear();
 		this._diagnosticCollection.set(document.uri, diagnostics);
+		const analysisTypeMsg = `${symbolicAnalysisEnabled ? 'with' : 'without'}`;
 		logger.debug(
-			`Full diagnostics ${symbolicAnalysisEnabled ? 'with' : 'without'} symbolic analysis performed in ${Date.now() - start}ms`
+			`${logPrefix} Full diagnostics ${analysisTypeMsg} symbolic analysis performed in ${Date.now() - start}ms`
 		);
 	}
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,8 +4,10 @@ import { gleeceContext } from './context/context';
 import { logger } from './logging/logger';
 
 export async function activate(context: ExtensionContext) {
+	const logPrefix: string = '[Gleece.activate]';
+
 	const start = Date.now();
-	logger.debug('Gleece Extension activating...');
+	logger.debug(`${logPrefix} Extension activating...`);
 
 	await gleeceContext.init(context);
 	context.subscriptions.push(gleeceContext);
@@ -17,18 +19,20 @@ export async function activate(context: ExtensionContext) {
 		() => {
 			if (window.activeTextEditor) {
 				gleeceContext.diagnosticsProvider.onDemandFullDiagnostics(window.activeTextEditor.document)
-					.catch((err) => logger.error('Could not analyze file', err));
+					.catch((err) => logger.error(`${logPrefix} Could not analyze file`, err));
 			}
 		},
 		500
 	);
 
-	logger.debug(`Gleece Extension activated in ${Date.now() - start}ms`);
+	logger.debug(`${logPrefix} Extension activated in ${Date.now() - start}ms`);
 }
 
 export function deactivate() {
-	logger.debug('Gleece Extension deactivating...');
+	const logPrefix: string = '[Gleece.deactivate]';
+
+	logger.debug(`${logPrefix} Extension deactivating...`);
 	const start = Date.now();
 	gleeceContext.dispose();
-	logger.debug(`Gleece Extension deactivated in ${Date.now() - start}ms`);
+	logger.debug(`${logPrefix} Extension deactivated in ${Date.now() - start}ms`);
 }

--- a/src/hover/semantic.hover.provider.ts
+++ b/src/hover/semantic.hover.provider.ts
@@ -56,6 +56,11 @@ export class SemanticHoverProvider implements HoverProvider {
 		position: Position,
 		_token: CancellationToken
 	): ProviderResult<Hover> {
+		if (!gleeceContext.configManager.isGleeceProject) {
+			// Not a gleece project, no need to create hovers
+			return undefined;
+		}
+
 		const line = document.lineAt(position);
 		const text = line.text.trim();
 

--- a/src/hover/simple.hover.provider.ts
+++ b/src/hover/simple.hover.provider.ts
@@ -9,6 +9,7 @@ import {
 } from 'vscode';
 import { AttributeDescriptions, AttributeNames } from '../enums';
 import { getAnnotationProvider } from '../annotation/annotation.functional';
+import { gleeceContext } from '../context/context';
 
 export class SimpleHoverProvider implements HoverProvider {
 
@@ -18,6 +19,11 @@ export class SimpleHoverProvider implements HoverProvider {
 		position: Position,
 		_token: CancellationToken
 	): ProviderResult<Hover> {
+		if (!gleeceContext.configManager.isGleeceProject) {
+			// Not a gleece project, no need to create hovers
+			return undefined;
+		}
+
 		const line = document.lineAt(position);
 		const text = line.text.trim();
 

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -1,10 +1,18 @@
 import { Disposable, OutputChannel, window } from 'vscode';
+import { GleeceCapitalized } from '../common.constants';
+
+export enum LogLevel {
+	Debug = 'DEBUG',
+	Info = 'INFO',
+	Warn = 'WARN',
+	Error = 'ERROR'
+}
 
 class Logger implements Disposable {
 	private _channel: OutputChannel;
 
 	public constructor() {
-		this._channel = window.createOutputChannel('Gleece');
+		this._channel = window.createOutputChannel(GleeceCapitalized);
 	}
 
 	public debug(message: string): void {
@@ -33,6 +41,44 @@ class Logger implements Disposable {
 		this.write(`[ERROR] ${message}`);
 		if (error) {
 			this.write(typeof error === 'string' ? error : error.toString());
+		}
+	}
+
+	public timeOperation<T>(label: string, fn: () => T, level?: LogLevel): T {
+		const start = performance.now();
+		const result = fn();
+		const end = performance.now();
+		this.writePerfMessage(level ?? LogLevel.Debug, label, start, end);
+		return result;
+	}
+
+	public async timeOperationAsync<T>(label: string, fn: () => PromiseLike<T>, level?: LogLevel): Promise<T> {
+		const start = performance.now();
+		const result = await fn();
+		const end = performance.now();
+		this.writePerfMessage(level ?? LogLevel.Debug, label, start, end);
+		return result;
+	}
+
+	private formatPerfMessage(label: string, start: number, end: number): string {
+		return `${label} took ${(end - start).toFixed(2)}ms`;
+	}
+
+	private writePerfMessage(level: LogLevel, label: string, start: number, end: number): void {
+		const message = this.formatPerfMessage(label, start, end);
+		switch (level) {
+			case LogLevel.Debug:
+				this.debug(message);
+				break;
+			case LogLevel.Info:
+				this.info(message);
+				break;
+			case LogLevel.Warn:
+				this.warn(message);
+				break;
+			case LogLevel.Error:
+				this.error(message);
+				break;
 		}
 	}
 

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -32,8 +32,8 @@ class Logger implements Disposable {
 		window.showWarningMessage(message);
 	}
 
-	public errorPopup(message: string): void {
-		this.warn(message);
+	public errorPopup(message: string, logPrefix?: string): void {
+		this.warn(`${logPrefix ? `${logPrefix} ` : ''}${message}`);
 		window.showErrorMessage(message);
 	}
 


### PR DESCRIPTION
Fixed issues relating to Gleece Config loading

Extension will now check `go.mod` for presence of the `github.com/gopher-fleece/runtime` package.
  If not found, the extension will stay activated but in a no-op mode, meaning it'll listen in for events but not attempt to load Gleece config or provide diagnostics or hovers.

Additional changes:

* Improved output channel logs
* Added crude performance traces via the logger's `timeOperation` and `timeOperationAsync` methods